### PR TITLE
fix : 빌드 테스트 실패

### DIFF
--- a/src/main/resources/yaml/application-log.yml
+++ b/src/main/resources/yaml/application-log.yml
@@ -9,7 +9,12 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+  # 테이블 생성 후에 data.sql 실행
+  defer-datasource-initialization: true
 
+  h2:
+    console:
+      enabled: true
 logging:
   level:
     org:


### PR DESCRIPTION
- JdbcSQLSyntaxErrorException
- 원인 빌드 후 자동으로 테이블 생성쿼리가 돌지 않았을 때

테스트 시에만 작동하도록 설정 필요