### PR TITLE
fix : toH2Console() 비활성화

### DIFF
--- a/src/main/java/me/kimyeonsup/blog/config/WebOAuthSecurityConfig.java
+++ b/src/main/java/me/kimyeonsup/blog/config/WebOAuthSecurityConfig.java
@@ -1,7 +1,5 @@
 package me.kimyeonsup.blog.config;
 
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
-
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import me.kimyeonsup.blog.config.jwt.TokenAuthenticationFilter;
@@ -34,13 +32,13 @@ public class WebOAuthSecurityConfig {
     @Bean
     public WebSecurityCustomizer configure() {
         return (web) -> web.ignoring()
-                .requestMatchers(toH2Console())
+//                .requestMatchers(toH2Console())
                 .requestMatchers("/img/**", "/css/**", "/js/**");
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(clsf -> clsf.disable())
+        http.csrf(csrf -> csrf.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .formLogin(formLogin -> formLogin.disable())
                 .logout(logout -> logout.disable());


### PR DESCRIPTION
Spring Security 구성에서 H2 데이터베이스 콘솔에 대한 요청 매처를 설정
 보통은 개발 환경에서만 사용되며, 운영 환경에서는 비활성화 처리